### PR TITLE
Implementa funcionalidade para excluir perguntas do formulário

### DIFF
--- a/src/com/raulmaciel/model/MenuPrincipal.java
+++ b/src/com/raulmaciel/model/MenuPrincipal.java
@@ -2,13 +2,16 @@ package com.raulmaciel.model;
 
 import com.raulmaciel.cadastro.CadastroPergunta;
 import com.raulmaciel.cadastro.CadastroUsuario;
+import com.raulmaciel.util.FileUtil;
 import com.raulmaciel.util.UsuarioUtil;
 
+import java.io.IOException;
 import java.util.InputMismatchException;
 import java.util.Scanner;
 
 public class MenuPrincipal {
     private static final Scanner scanner = new Scanner(System.in);
+    private static final String filePath = "data/formulario.txt";
 
     public static void callMenu(){
         try {
@@ -40,7 +43,12 @@ public class MenuPrincipal {
                     callMenu();
                     break;
                 case 4:
-                    System.out.println("Feature em desenvolvimento!");
+                    System.out.println("\n\t-=-=-= Deletar Pergunta -=-=-=");
+                    try {
+                        FileUtil.deleteLine(filePath);
+                    } catch (IOException e) {
+                        System.out.println("Impossivel ler formulario: " + e.getMessage());
+                    }
                     callMenu();
                     break;
                 case 5:

--- a/src/com/raulmaciel/util/FileUtil.java
+++ b/src/com/raulmaciel/util/FileUtil.java
@@ -5,16 +5,18 @@ import com.raulmaciel.exception.LeituraArquivoException;
 import java.io.*;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Scanner;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class FileUtil {
+    private static final Scanner scanner = new Scanner(System.in);
 
-    public static List<String> readForm(String formPath){
+    public static List<String> readForm(String formPath) {
         List<String> textoFormulario = new ArrayList<>();
-        try(BufferedReader reader = new BufferedReader(new FileReader(formPath))) {
+        try (BufferedReader reader = new BufferedReader(new FileReader(formPath))) {
             String linha;
-            while ((linha = reader.readLine()) != null){
+            while ((linha = reader.readLine()) != null) {
                 textoFormulario.add(linha);
             }
 
@@ -25,20 +27,20 @@ public class FileUtil {
         return textoFormulario;
     }
 
-    public static void printForm(List<String> readForm){
+    public static void printForm(List<String> readForm) {
         System.out.println("-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=");
         System.out.println("\t\t\t\tCadastro de Usuário");
         System.out.println("-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=");
         readForm.forEach(System.out::println);
     }
 
-    public static void writeForm(String filePath, List<String> text){
-        try(BufferedWriter writer = new BufferedWriter(new FileWriter(filePath, true))) {
-            List<String> formulario = FileUtil.readForm(filePath);
+    public static void writeForm(String filePath, List<String> text) {
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(filePath, true))) {
+            List<String> formulario = readForm(filePath);
             int i = formulario.size();
             for (String linha : text) {
                 writer.newLine();
-                writer.write((i+1) + " - " + linha);
+                writer.write((i + 1) + " - " + linha);
             }
 
 
@@ -47,30 +49,43 @@ public class FileUtil {
         }
     }
 
-    public static void listarArquivos(String diretorioPath){
+    public static void writeFormAppendOff(String filePath, List<String> text) {
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(filePath))) {
+            for (String linha : text) {
+                writer.write(linha);
+                writer.newLine();
+            }
+
+
+        } catch (IOException e) {
+            System.out.println("Erro ao escrever no arquivo: " + e.getMessage());
+        }
+    }
+
+    public static void listarArquivos(String diretorioPath) {
         try {
             File diretorio = new File(diretorioPath);
-            if (diretorio.exists() && diretorio.isDirectory()){
+            if (diretorio.exists() && diretorio.isDirectory()) {
                 File[] arquivos = diretorio.listFiles();
 
-                if (arquivos != null){
-                for (File arquivo : arquivos) {
-                    try(BufferedReader reader = new BufferedReader(new FileReader(arquivo))) {
-                        String nomeArquivo = arquivo.getName();
-                        String regex = "^\\d-[A-Z]+.txt";
+                if (arquivos != null) {
+                    for (File arquivo : arquivos) {
+                        try (BufferedReader reader = new BufferedReader(new FileReader(arquivo))) {
+                            String nomeArquivo = arquivo.getName();
+                            String regex = "^\\d-[A-Z]+.txt";
 
-                        Pattern pattern = Pattern.compile(regex);
-                        Matcher matcher = pattern.matcher(nomeArquivo);
+                            Pattern pattern = Pattern.compile(regex);
+                            Matcher matcher = pattern.matcher(nomeArquivo);
 
-                        if(matcher.find()){
-                            System.out.println(arquivo.getName().charAt(0) + " - "+ reader.readLine());
+                            if (matcher.find()) {
+                                System.out.println(arquivo.getName().charAt(0) + " - " + reader.readLine());
+                            }
+
+                        } catch (IOException e) {
+                            throw new RuntimeException(e);
                         }
-
-                    } catch (IOException e) {
-                        throw new RuntimeException(e);
                     }
-                }
-                }else {
+                } else {
                     System.out.println("O diretorio não possui arquivos");
                 }
 
@@ -78,6 +93,43 @@ public class FileUtil {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public static void deleteLine(String filePath) throws IOException {
+        List<String> form = readForm(filePath);
+        List<String> formUpdated = new ArrayList<>();
+
+        for (int i = 0; i <form.size(); i++) {
+            System.out.println("["+i+"]" + form.get(i));
+        }
+        System.out.print("Qual pergunta deseja excluir?: ");
+        int indexToRemove = scanner.nextInt();
+
+        if (form.isEmpty()) {
+            System.err.println("Erro: O arquivo está vazio.");
+            return;
+        }
+
+        if (indexToRemove < 0 || indexToRemove > form.size()) {
+            System.err.println("Erro: Número da linha inválido.");
+            return;
+        }
+
+        if (indexToRemove <= 3) {
+            System.err.println("Erro: Você não pode excluir as perguntas nativas.");
+            return;
+        }
+
+
+        for (int i = 0; i < form.size(); i++) {
+            if (i != indexToRemove) {
+                formUpdated.add(form.get(i));
+            }
+        }
+
+
+        writeFormAppendOff(filePath, formUpdated);
+        System.out.println("Linha removida com sucesso!");
     }
 
 }


### PR DESCRIPTION
O que foi feito?

✅ Implementada funcionalidade para remover perguntas do arquivo formulario.txt.
✅ O usuário pode escolher qual pergunta excluir pelo número.
✅ Ajustado o índice para refletir corretamente a numeração exibida ao usuário (1-based index).
✅ Implementada regra de restrição para impedir a remoção das 4 primeiras perguntas nativas.
✅ Tratamento de erro para evitar remoção inválida e garantir que o índice fornecido esteja dentro do limite do arquivo.
✅ Mensagens de erro claras para o usuário ao tentar remover uma pergunta inválida.

📌 Como testar?

1️⃣ Acesse o menu e escolha a opção de excluir perguntas.
2️⃣ Digite um número de pergunta maior que 4 e confirme que foi removida corretamente.
3️⃣ Tente excluir uma das 4 primeiras perguntas e verifique se a restrição está funcionando.
4️⃣ Tente excluir um número inválido (exemplo: maior que o total de perguntas) e veja se o sistema exibe a mensagem de erro correta.
5️⃣ Verifique se o formulario.txt foi atualizado corretamente após a exclusão.